### PR TITLE
Bugs in spiral_varden

### DIFF
--- a/pulpy/grad/waveform.py
+++ b/pulpy/grad/waveform.py
@@ -156,6 +156,7 @@ def spiral_varden(fov, res, gts, gslew, gamp, densamp, dentrans, nl, rewinder=Fa
         Code and algorithm based on spiralgradlx6 from
         Doug Noll, U. of Michigan BME
     """
+    gslew /= 100 # following actually assume that gslew is in T/m/s (or G/cm/cs)
     fsgcm = gamp  # fullscale g/cm
     risetime = gamp / gslew * 10000  # us
     ts = gts  # sampling time

--- a/pulpy/grad/waveform.py
+++ b/pulpy/grad/waveform.py
@@ -314,19 +314,17 @@ def spiral_varden(fov, res, gts, gslew, gamp, densamp, dentrans, nl, rewinder=Fa
 
     # rewinder
     if rewinder:
-        rewx, ramppts = np.squeeze(
-            trap_grad(abs(np.real(sum(g))) * gts, gamp, gslew * 50, gts)
-        )
-        rewy, ramppts = np.squeeze(
-            trap_grad(abs(np.imag(sum(g))) * gts, gamp, gslew * 50, gts)
-        )
+        rewx, ramppts = trap_grad(abs(np.real(sum(g))) * gts, gamp, gslew * 50, gts)
+        rewy, ramppts = trap_grad(abs(np.imag(sum(g))) * gts, gamp, gslew * 50, gts)
+        
+        rewx, rewy = rewx.squeeze(), rewy.squeeze()
 
         # append rewinder gradient
         if len(rewx) > len(rewy):
             r = -np.sign(np.real(sum(g))) * rewx
             p = np.sign(np.imag(sum(g)))
             p *= 1j * np.abs(np.imag(sum(g))) / np.real(sum(g)) * rewx
-            r -= p
+            r = r - p
         else:
             p = -np.sign(np.real(sum(g)))
             p *= np.abs(np.real(sum(g)) / np.imag(sum(g))) * rewy


### PR DESCRIPTION
Hi,
thank you very much for this nice package, it is really useful to have this decoupled from the main SigPy toolbox.
I am currently working on some PyPulseq wrappers around spiral_varden routines. However, I noticed that the routine fails when "rewinder=True":

*** ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (2,) + inhomogeneous part.

The offending lines (317-322) are:

rewx, ramppts = np.squeeze(
            trap_grad(abs(np.real(sum(g))) * gts, gamp, gslew * 50, gts)
        )
        rewy, ramppts = np.squeeze(
            trap_grad(abs(np.imag(sum(g))) * gts, gamp, gslew * 50, gts)
        )

I am not sure if this is only related with recent numpy releases (I am using 1.26.4 here), but this PR should fix it for any release.

In addition, gslew units (G/cm/sec) in docstring seems wrong, as the code actually assume input values are "T/m/s" (or "G/cm/cs"): see for instance line 160, where the ratio between "gamp" (in "G/cm") and "gslew" is multiplied by 1e4 (instead of 1e6) to obtain us. I have fixed this by pre-dividing the slew rate by 100 at the beginning of the code: I think it makes sense to maintain homogeneous G/cm and G/cm/sec units in the docstring, rather than having a cumbersome G/cm and T/m/s.

All the best,
Matteo  