### PR TITLE
Adjust gslew scaling factor to mT/m/s

### DIFF
--- a/pulpy/grad/waveform.py
+++ b/pulpy/grad/waveform.py
@@ -374,7 +374,7 @@ def spiral_arch(fov, res, gts, gslew, gamp):
         Bernstein, M.A.; King, K.F.; amd Zhou, X.J. (2004).
         Handbook of MRI Pulse Sequences. Elsevier.
     """
-
+    gslew *= 1000.0 # following code actually assumes mT/m/s
     gam = 267.522 * 1e6 / 1000  # rad/s/mT
     gambar = gam / 2 / np.pi  # Hz/mT
     N = int(fov / res)  # effective matrix size


### PR DESCRIPTION
spiral_arch() docstrings states input slew rate is in mT/m/ms, but internally it is treated as mT/m/s, hence requiring input slew rate gslew * 1000 to get correctly designed waveforms - otherwise, slew rate will be always too small and spiral will never reach amplitude-limited regime and have extra long readouts. This fix rescales input gslew internally, so that API is consistent with docstring.

However, upon fixing that, tests for ptx design fails. I looked into it and found some suspicious calls to spiral_arch() that I would like to clarify before attempting to fix that:

line 120 (test_ptx.py):

`g, k1, t, s = waveform.spiral_arch(0.24, dim, 4e-6, 200, 0.035)`

with `dim = target.shape[0]` - why is so? it looks like dim is a sort of integer matrix size, while spiral_arch() would expect resolution.
Also input gmax seems unreasonable (0.035 mT/m)

Indeed, lines 90-98 in the same file have a much more reasonable call:

```Python
fov = 0.55
gts = 6.4e-6
gslew = 190
gamp = 40
R = 1
dx = 0.025  # in m
# construct a trajectory
g, k, t, s = waveform.spiral_arch(fov / R, dx, gts, gslew, gamp)
```
Thanks again for the package!
